### PR TITLE
Feature/unitest run all

### DIFF
--- a/os/services/unit-test/unit-test.c
+++ b/os/services/unit-test/unit-test.c
@@ -38,6 +38,10 @@
 
 #include "unit-test.h"
 
+void (*test_list[MAX_UTS])();
+uint32_t test_size = 0;
+
+
 /*---------------------------------------------------------------------------*/
 /**
  * Print the results of a unit test.

--- a/tests/07-simulation-base/code-data-structures/test-data-structures.c
+++ b/tests/07-simulation-base/code-data-structures/test-data-structures.c
@@ -1032,13 +1032,7 @@ PROCESS_THREAD(data_structure_test_process, ev, data)
   printf("---\n");
 
   memset(elements, 0, sizeof(elements));
-
-  UNIT_TEST_RUN(test_list);
-  UNIT_TEST_RUN(test_stack);
-  UNIT_TEST_RUN(test_queue);
-  UNIT_TEST_RUN(test_csll);
-  UNIT_TEST_RUN(test_dll);
-  UNIT_TEST_RUN(test_cdll);
+  RUN_ALL();
 
   printf("=check-me= DONE\n");
 


### PR DESCRIPTION
This is a draft of possible simplifications for writing unit tests.

`RUN_ALL` macro runs all tests.

The unit test is registered during declaration of `UNIT_TEST` by special macro `_UNIT_TEST_INITIALIZER` which use `__attribute__((constructor))` mark to run registration before running main.

Limitations:
* It's possible it will not work with some compilators (e.g. clang require something others), but I found that generally `__attribute__((constructor))` should be available (this is gcc extension). But anyway, this is for simplify UT creations, not for general development
* Size for list of tests must be declared statically (but it is a problem to overallocate memory for test?)

Other possible improvements:
* don't use `UNIT_TEST_REGISTER`, merge it with `UNIT_TEST`
